### PR TITLE
refactor : SOLID-ProductEntity

### DIFF
--- a/src/main/java/com/sparta/uglymarket/entity/ProductEntity.java
+++ b/src/main/java/com/sparta/uglymarket/entity/ProductEntity.java
@@ -1,6 +1,5 @@
 package com.sparta.uglymarket.entity;
 
-import com.sparta.uglymarket.dto.ProductCreateRequest;
 import com.sparta.uglymarket.dto.ProductUpdateRequest;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -35,15 +34,6 @@ public class ProductEntity {
 
     @Column(nullable = false)
     private String category; // 상품 카테고리
-
-    public ProductEntity(ProductCreateRequest productCreateRequest) {
-        this.title = productCreateRequest.getTitle();
-        this.content = productCreateRequest.getContent();
-        this.price = productCreateRequest.getPrice();
-        this.stock = productCreateRequest.getStock();
-        this.imageUrl = productCreateRequest.getImageUrl();
-        this.category = productCreateRequest.getCategory();
-    }
 
     public void updateFromRequest(ProductUpdateRequest productUpdateRequest) {
         this.title = productUpdateRequest.getTitle();

--- a/src/main/java/com/sparta/uglymarket/entity/TokenType.java
+++ b/src/main/java/com/sparta/uglymarket/entity/TokenType.java
@@ -1,5 +1,5 @@
 package com.sparta.uglymarket.entity;
 
-public enum TokenType {
+public enum dfTokenType {
     REFRESH
 }

--- a/src/main/java/com/sparta/uglymarket/factory/ProductFactory.java
+++ b/src/main/java/com/sparta/uglymarket/factory/ProductFactory.java
@@ -1,0 +1,21 @@
+package com.sparta.uglymarket.factory;
+
+import com.sparta.uglymarket.dto.ProductCreateRequest;
+import com.sparta.uglymarket.entity.ProductEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProductFactory {
+
+    public ProductEntity createProduct(ProductCreateRequest productCreateRequest) {
+        return new ProductEntity(
+                null,
+                productCreateRequest.getTitle(),
+                productCreateRequest.getContent(),
+                productCreateRequest.getPrice(),
+                productCreateRequest.getStock(),
+                productCreateRequest.getImageUrl(),
+                productCreateRequest.getCategory()
+        );
+    }
+}

--- a/src/main/java/com/sparta/uglymarket/service/ProductService.java
+++ b/src/main/java/com/sparta/uglymarket/service/ProductService.java
@@ -4,6 +4,7 @@ import com.sparta.uglymarket.dto.*;
 import com.sparta.uglymarket.exception.ErrorMsg;
 import com.sparta.uglymarket.entity.ProductEntity;
 import com.sparta.uglymarket.exception.CustomException;
+import com.sparta.uglymarket.factory.ProductFactory;
 import com.sparta.uglymarket.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -20,6 +21,7 @@ import java.util.stream.Collectors;
 public class ProductService {
 
     private final ProductRepository productRepository;
+    private final ProductFactory productFactory;
 
     // 상품 생성
     public ProductCreateResponse createProduct(ProductCreateRequest productCreateRequest) {
@@ -59,7 +61,7 @@ public class ProductService {
 
     // DTO를 엔티티로 변환
     private ProductEntity convertToEntity(ProductCreateRequest productCreateRequest) {
-        return new ProductEntity(productCreateRequest);
+        return productFactory.createProduct(productCreateRequest);
     }
 
     // 엔티티 저장


### PR DESCRIPTION
## 🛠️ 작업 내용
- SOLID 의 SRP 단일책임 원칙을 준수하며 코드 수정
- 엔티티 클래스 내에서 데이터 변경 메서드는 엔티티 자체의 일관성을 유지하고 불변성을 보장하기 위해 필요할 수도 있어서 외부로 분리하지 않음.
<br/>